### PR TITLE
Fix for LED Control / Tone, Wemos D1 R32 Pin Configurations, and Anti-Poisoning Flicker Mode

### DIFF
--- a/ESP32_NTPNixieClock.ino
+++ b/ESP32_NTPNixieClock.ino
@@ -197,7 +197,8 @@ void updateDisplay(void) {
     SHIELD.setLEDColor(red);
 
     // Do anti-poisoning function
-    SHIELD.doAntiPoisoning();
+    SHIELD.doAntiPoisoning(false); // Normal Mode
+    //SHIELD.doAntiPoisoning(true); // Flicker Mode
   }
 
   // 15 minute event is rainbow display
@@ -468,7 +469,8 @@ void setup() {
   SHIELD.hvEnable(true);
 
   // Do the anti poisoning routine
-  SHIELD.doAntiPoisoning();
+  SHIELD.doAntiPoisoning(false); // Normal Mode
+  //SHIELD.doAntiPoisoning(true); // Flicker Mode
 
   Serial.println("\nReady!\n");
 }

--- a/ESP32_NTPNixieClock.ino
+++ b/ESP32_NTPNixieClock.ino
@@ -153,8 +153,10 @@ void updateDisplay(void) {
       clockOn = true;
       Serial.println("Clock is On");
 
-      // Clock should be on so turn high voltage on
-      SHIELD.hvEnable(true);
+      #ifndef ESP32_WEMOS_D1_R32
+          // Clock should be on so turn high voltage on
+          SHIELD.hvEnable(true);
+      #endif
     }
   } else  {
     if (clockOn) {
@@ -162,9 +164,11 @@ void updateDisplay(void) {
 
       Serial.println("Clock is Off");
 
-      // Clock is going off so shut things down in an orderly fashion
-      // First turn off the high voltage so the nixie's go off
-      SHIELD.hvEnable(false);
+      #ifndef ESP32_WEMOS_D1_R32
+          // Clock is going off so shut things down in an orderly fashion
+          // First turn off the high voltage so the nixie's go off
+          SHIELD.hvEnable(false);
+      #endif
 
       // Next turn off the dots
       SHIELD.dotsEnable(false);
@@ -418,8 +422,10 @@ void WIFI_StartAccessPoint() {
 // ***************************************************************
 
 void setup() {
-  // Turn off the high voltage for the clock
-  SHIELD.hvEnable(false);
+  #ifndef ESP32_WEMOS_D1_R32
+      // Turn off the high voltage for the clock
+      SHIELD.hvEnable(false);
+  #endif
 
   // Turn off DAC channels
   dac_output_disable(DAC_CHANNEL_1);
@@ -465,8 +471,10 @@ void setup() {
   // Turn off the dots
   SHIELD.dotsEnable(false);
 
-  // Turn on the high voltage for the clock
-  SHIELD.hvEnable(true);
+  #ifndef ESP32_WEMOS_D1_R32
+      // Turn on the high voltage for the clock
+      SHIELD.hvEnable(true);
+  #endif
 
   // Do the anti poisoning routine
   SHIELD.doAntiPoisoning(false); // Normal Mode

--- a/ESP32_NTPNixieClock.ino
+++ b/ESP32_NTPNixieClock.ino
@@ -106,6 +106,16 @@
 #define CLOCK_OFF_HOUR 23
 #define CLOCK_ON_HOUR  07
 
+// Sets the AntiPoisoning "animation"
+// When true, it creates a chaotic random flickering effect across all
+// nixie digits for anti-poisoning, while false cycles all digits sequentially
+//  with LED color changes and dot blinking.
+bool flickerMode = false; // Default to normal mode
+
+// Uncoment this inside the NixieTubeShield.h 
+// If using a Wemos D1 R32 board to define correct pins
+//#define ESP32_WEMOS_D1_R32
+
 // Suppress leading zeros
 // Set to false to having leading zeros displayed
 #define SUPPRESS_LEADING_ZEROS true
@@ -201,8 +211,7 @@ void updateDisplay(void) {
     SHIELD.setLEDColor(red);
 
     // Do anti-poisoning function
-    SHIELD.doAntiPoisoning(false); // Normal Mode
-    //SHIELD.doAntiPoisoning(true); // Flicker Mode
+    SHIELD.doAntiPoisoning(flickerMode);
   }
 
   // 15 minute event is rainbow display
@@ -477,8 +486,7 @@ void setup() {
   #endif
 
   // Do the anti poisoning routine
-  SHIELD.doAntiPoisoning(false); // Normal Mode
-  //SHIELD.doAntiPoisoning(true); // Flicker Mode
+  SHIELD.doAntiPoisoning(flickerMode);
 
   Serial.println("\nReady!\n");
 }

--- a/ESP32_NTPNixieClock.ino
+++ b/ESP32_NTPNixieClock.ino
@@ -505,6 +505,7 @@ void loop() {
 
   // If set button is long-pressed, restart ESP
   if (SHIELD.isSetButtonLongClicked()) {
+    Serial.println("Restarting ESP");
     esp_restart();
   }
 

--- a/LEDControl.h
+++ b/LEDControl.h
@@ -25,9 +25,9 @@ RGB24 magenta = {127,   0, 127};
 RGB24 yellow  = {127, 127,   0};
 RGB24 white   = {127, 127, 127};
 
-#define LED_RED_CHANNEL 1
-#define LED_GREEN_CHANNEL 2
-#define LED_BLUE_CHANNEL 3
+//#define LED_RED_CHANNEL 1
+//#define LED_GREEN_CHANNEL 2
+//#define LED_BLUE_CHANNEL 3
 
 // LEDControl Class Definition
 class LEDControl {
@@ -46,18 +46,28 @@ class LEDControl {
       pinMode(bluePin,  OUTPUT);
 
       // Each channel is set up for 12kHz and 10-bit resolution
-      ledcSetup(LED_RED_CHANNEL, 12000, 10);
-      ledcSetup(LED_GREEN_CHANNEL, 12000, 10);
-      ledcSetup(LED_BLUE_CHANNEL, 12000, 10);
+      //ledcSetup(LED_RED_CHANNEL, 12000, 10);
+      //ledcSetup(LED_GREEN_CHANNEL, 12000, 10);
+      //ledcSetup(LED_BLUE_CHANNEL, 12000, 10);
 
-      ledcAttachPin(redPin, LED_RED_CHANNEL);
-      ledcAttachPin(greenPin, LED_GREEN_CHANNEL);
-      ledcAttachPin(bluePin, LED_BLUE_CHANNEL);
+      //ledcAttachPin(redPin, LED_RED_CHANNEL);
+      //ledcAttachPin(greenPin, LED_GREEN_CHANNEL);
+      //ledcAttachPin(bluePin, LED_BLUE_CHANNEL);
 
       // Turn off RGB LEDs
-      ledcWrite(LED_RED_CHANNEL, 0);
-      ledcWrite(LED_GREEN_CHANNEL, 0);
-      ledcWrite(LED_BLUE_CHANNEL, 0);
+      //ledcWrite(LED_RED_CHANNEL, 0);
+      //ledcWrite(LED_GREEN_CHANNEL, 0);
+      //ledcWrite(LED_BLUE_CHANNEL, 0);
+
+      // Each channel is set up for 12kHz and 10-bit resolution        
+      ledcAttach(redPin, 12000, 10);
+      ledcAttach(greenPin, 12000, 10);
+      ledcAttach(bluePin, 12000, 10);
+
+      // Turn off RGB LEDs
+      ledcWrite(redPin, 0);
+      ledcWrite(greenPin, 0);
+      ledcWrite(bluePin, 0);
     }
 
     // Input a value 0 to 255 to get a color value.
@@ -99,9 +109,12 @@ class LEDControl {
       int rblu = map(blue,  0, 255, 0, 1023);
 
       // Use PWM to control LED brightness
-      ledcWrite(LED_RED_CHANNEL, rred);
-      ledcWrite(LED_GREEN_CHANNEL, rgrn);
-      ledcWrite(LED_BLUE_CHANNEL, rblu);
+      //ledcWrite(LED_RED_CHANNEL, rred);
+      //ledcWrite(LED_GREEN_CHANNEL, rgrn);
+      //ledcWrite(LED_BLUE_CHANNEL, rblu);
+      ledcWrite(redPin, rred);
+      ledcWrite(greenPin, rgrn);
+      ledcWrite(bluePin, rblu);
     }
 
     // Set the RGB LEDs color

--- a/LEDControl.h
+++ b/LEDControl.h
@@ -25,9 +25,9 @@ RGB24 magenta = {127,   0, 127};
 RGB24 yellow  = {127, 127,   0};
 RGB24 white   = {127, 127, 127};
 
-//#define LED_RED_CHANNEL 1
-//#define LED_GREEN_CHANNEL 2
-//#define LED_BLUE_CHANNEL 3
+#define LED_RED_CHANNEL 1
+#define LED_GREEN_CHANNEL 2
+#define LED_BLUE_CHANNEL 3
 
 // LEDControl Class Definition
 class LEDControl {
@@ -60,9 +60,9 @@ class LEDControl {
       //ledcWrite(LED_BLUE_CHANNEL, 0);
 
       // Each channel is set up for 12kHz and 10-bit resolution        
-      ledcAttach(redPin, 12000, 10);
-      ledcAttach(greenPin, 12000, 10);
-      ledcAttach(bluePin, 12000, 10);
+      ledcAttachChannel(redPin, 12000, 10, LED_RED_CHANNEL);
+      ledcAttachChannel(greenPin, 12000, 10, LED_GREEN_CHANNEL);
+      ledcAttachChannel(bluePin, 12000, 10, LED_BLUE_CHANNEL);
 
       // Turn off RGB LEDs
       ledcWrite(redPin, 0);

--- a/NixieTubeShield.h
+++ b/NixieTubeShield.h
@@ -183,28 +183,69 @@ class NixieTubeShield : public LEDControl {
     }
 
     // Do anti-poisoning routine and then turn off all tubes
-    void doAntiPoisoning(void) {
+    void doAntiPoisoning(int flickerMode) {
       bool dots = false;
       dotsEnable(false);
 
-      for (int j = 0; j < 4; j++) {
-        for (int i = 0; i < 11; i++) {
-          setNX1Digit(i);
-          setNX2Digit(i);
-          setNX3Digit(i);
-          setNX4Digit(i);
-          setNX5Digit(i);
-          setNX6Digit(i);
+      if(flickerMode){
+        // Arrays to track current and target digits for each tube
+        byte currentDigits[6] = {0, 0, 0, 0, 0, 0};
+        byte targetDigits[6] = {0, 0, 0, 0, 0, 0};
 
-          // Make the changes visible
-          show();
+        // Randomize target digits for each tube
+        for (int i = 0; i < 6; i++) {
+            targetDigits[i] = random(0, 10); // Target random digit from 0-9
+        }
 
-          // Small delay
-          delay(500);
+        for (int iteration = 0; iteration < 60; iteration++) { // Run for 3 seconds (60 x 50ms)
+            for (int i = 0; i < 6; i++) {
+                // Increment current digit towards the target digit, with wrap-around
+                if (currentDigits[i] != targetDigits[i]) {
+                    currentDigits[i] = (currentDigits[i] + 1) % 10;
+                } else {
+                    // Assign a new random target digit when the current matches the target
+                    targetDigits[i] = random(0, 10);
+                }
+            }
 
-          setLEDColor(i%3==0?255:0, i%3==1?255:0, i%3==2?255:0);
-          dots = !dots;
-          dotsEnable(dots);
+            // Set each digit of the nixie tubes
+            setNX1Digit(currentDigits[0]);
+            setNX2Digit(currentDigits[1]);
+            setNX3Digit(currentDigits[2]);
+            setNX4Digit(currentDigits[3]);
+            setNX5Digit(currentDigits[4]);
+            setNX6Digit(currentDigits[5]);
+
+            // Make the changes visible
+            show();
+
+            // Small delay for flickering effect
+            delay(50);
+
+            // Alternate the dots
+            dots = !dots;
+            dotsEnable(dots);
+        }
+      } else {
+        for (int j = 0; j < 4; j++) {
+          for (int i = 0; i < 11; i++) {
+            setNX1Digit(i);
+            setNX2Digit(i);
+            setNX3Digit(i);
+            setNX4Digit(i);
+            setNX5Digit(i);
+            setNX6Digit(i);
+
+            // Make the changes visible
+            show();
+
+            // Small delay
+            delay(500);
+
+            setLEDColor(i%3==0?255:0, i%3==1?255:0, i%3==2?255:0);
+            dots = !dots;
+            dotsEnable(dots);
+          }
         }
       }
     }

--- a/NixieTubeShield.h
+++ b/NixieTubeShield.h
@@ -134,7 +134,9 @@ class NixieTubeShield : public LEDControl {
 
     // Neon lamp control
     void dotsEnable(boolean state) {
-      digitalWrite(NEON_DOTS, state ? HIGH : LOW);
+      #ifndef ESP32_WEMOS_D1_R32
+        digitalWrite(NEON_DOTS, state ? HIGH : LOW);
+      #endif
       dotsEnabled = state;
     }
 

--- a/NixieTubeShield.h
+++ b/NixieTubeShield.h
@@ -16,16 +16,37 @@
 // ESP32 Pin Configuration
 // ***************************************************************
 
-#define LED_GREEN    A16
-#define LED_RED      A14
-#define LED_BLUE     A13
-#define HV_ENABLE     17  //TODO
-#define LATCH_ENABLE  SS
-#define NEON_DOTS    A18
-#define MODE_BUTTON  A15
-#define UP_BUTTON     16
-#define DOWN_BUTTON  A10
-#define BUZZER_PIN    A4
+//#define ESP32_WEMOS_D1_R32
+
+#ifdef ESP32_WEMOS_D1_R32
+    // Wemos D1 R32 Pin Definitions
+    #define LED_GREEN    27
+    #define LED_RED      13
+    #define LED_BLUE     25
+    #define LATCH_ENABLE SS  // SS (GPIO5)
+    #define MODE_BUTTON  2
+    #define UP_BUTTON     35
+    #define DOWN_BUTTON  4
+    #define BUZZER_PIN    26
+
+    // Not used in this Sctipt
+    // 14 - TMP
+    // 16 - SHDN
+    // 17 - IR
+    // 34 - LS
+#else
+    // Normal ESP32 Pin Definitions
+    #define LED_GREEN    A16
+    #define LED_RED      A14
+    #define LED_BLUE     A13
+    #define HV_ENABLE    17  //TODO
+    #define LATCH_ENABLE SS
+    #define NEON_DOTS    A18
+    #define MODE_BUTTON  A15
+    #define UP_BUTTON     16
+    #define DOWN_BUTTON  A10
+    #define BUZZER_PIN    A4
+#endif
 
 #define DS1307_ADDRESS 0x68
 
@@ -64,19 +85,27 @@ class NixieTubeShield : public LEDControl {
     // Class Constructor
     NixieTubeShield() : LEDControl(LED_RED, LED_GREEN, LED_BLUE) {
 
+      // Check if we're using Wemos D1 R32 or normal ESP32
+      #ifndef ESP32_WEMOS_D1_R32
+          // Normal ESP32 specific setup
+          // Setup output pins
+          pinMode(HV_ENABLE,    OUTPUT);
+          pinMode(NEON_DOTS,    OUTPUT);
+          //pinMode(NEON_DOTS_LOWER,    OUTPUT);
+        
+          // Set default outputs
+          digitalWrite(HV_ENABLE,    LOW);
+          digitalWrite(NEON_DOTS,    LOW);
+      #endif
+
       // Setup output pins
-      pinMode(HV_ENABLE,    OUTPUT);
       pinMode(LATCH_ENABLE, OUTPUT);
-      pinMode(NEON_DOTS,    OUTPUT);
       pinMode(MODE_BUTTON,  INPUT_PULLUP);
       pinMode(UP_BUTTON,  INPUT_PULLUP);
       pinMode(DOWN_BUTTON,  INPUT_PULLUP);
-      //pinMode(NEON_DOTS_LOWER,    OUTPUT);
-
-      // Set default outputs
-      digitalWrite(HV_ENABLE,    LOW);
+        
+      // Setup output pins
       digitalWrite(LATCH_ENABLE, LOW);
-      digitalWrite(NEON_DOTS,    LOW);
 
       setButton.debounceTime   = 20;   // Debounce timer in ms
       setButton.multiclickTime = 30;  // Time limit for multi clicks
@@ -96,10 +125,12 @@ class NixieTubeShield : public LEDControl {
       }
     }
 
-    // High voltage control
-    void hvEnable(boolean state) {
-      digitalWrite(HV_ENABLE, state ? HIGH : LOW);
-    }
+    #ifndef ESP32_WEMOS_D1_R32
+        // High voltage control
+        void hvEnable(boolean state) {
+          digitalWrite(HV_ENABLE, state ? HIGH : LOW);
+        }
+    #endif
 
     // Neon lamp control
     void dotsEnable(boolean state) {

--- a/NixieTubeShield.h
+++ b/NixieTubeShield.h
@@ -24,7 +24,7 @@
     #define LED_RED      13
     #define LED_BLUE     25
     #define LATCH_ENABLE SS  // SS (GPIO5)
-    #define MODE_BUTTON  2
+    #define MODE_BUTTON  2 // Can cause a boot loop since GPIO2 can trigger at boot which fires up the if with SHIELD.isSetButtonLongClicked() which causes esp_restart(); - can be commented out as workaround 
     #define UP_BUTTON     35
     #define DOWN_BUTTON  4
     #define BUZZER_PIN    26

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ ESP32 Pin    Shield Pin          Function
     A10           DOWN       Down button
     A4            BUZZER     Buzzer pin
 
+- **Added Support for Wemos D1 R32 Pin Configuration**:  
+  Enables correct pin definitions for the Wemos D1 R32 board, tested with an Arduino Shield Nixie IN-14 v2.2.
+
+  Uncomment the following line in `NixieTubeShield.h`:
+
+    ```cpp
+    //#define ESP32_WEMOS_D1_R32
+  ```
+    
 The ESP32 is powered (via Vin) with 5VDC from a 5 volt regulator driven from
 the 12 VDC supply. The shield is powered directly from the 12 VDC supply.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ ESP32 Pin    Shield Pin          Function
     ```cpp
     //#define ESP32_WEMOS_D1_R32
   ```
+
+INFO: 
+  For ESP32_WEMOS_D1_R32:
+        #define MODE_BUTTON  2 // Can cause a boot loop since GPIO2 can trigger at boot which fires up the if with SHIELD.isSetButtonLongClicked() which causes esp_restart() inside ESP32_NTPNixieClock.ino - can be commented out as workaround
     
 The ESP32 is powered (via Vin) with 5VDC from a 5 volt regulator driven from
 the 12 VDC supply. The shield is powered directly from the 12 VDC supply.

--- a/Tone.h
+++ b/Tone.h
@@ -103,12 +103,13 @@ public:
 	}
 
 	void begin(uint8_t pin) {
-     ledcSetup(TONE_CHANNEL, 1E5, 12);
-     ledcAttachPin(pin,TONE_CHANNEL);
+	     //ledcSetup(TONE_CHANNEL, 1E5, 12);
+	     //ledcAttachPin(pin,TONE_CHANNEL);
+	     ledcAttachChannel(pin, 1E5, 12, TONE_CHANNEL);
 	}
 
 	void play(unsigned int freq, unsigned long duration) {
-    ledcWriteTone(TONE_CHANNEL, freq);
+		ledcWriteTone(TONE_CHANNEL, freq);
 		// TODO
 		//tone(_pin, freq, duration);
 	}


### PR DESCRIPTION
**Fix for Issue #4**: [GitHub Issue #4](https://github.com/tverona1/ESP32_NTPNixieClock/issues/4)

- **LED Control / Tone Update**:  
  The following APIs were deprecated and replaced:
  - Removed: `ledcSetup`, `ledcAttachPin`
  - New: `ledcAttach` (combines the functionality of `ledcSetup` and `ledcAttachPin`).

  **Reference**: [Arduino-ESP32 Migration Guide](https://github.com/espressif/arduino-esp32/blob/master/docs/en/migration_guides/2.x_to_3.0.rst#ledc)

- **Added Support for Wemos D1 R32 Pin Configuration**:  
  Enables correct pin definitions for the Wemos D1 R32 board.

  To use this, uncomment the following line in `NixieTubeShield.h`:

    ```cpp
    //#define ESP32_WEMOS_D1_R32
  ```

  **Reference**: [GitHub Issue #2](https://github.com/tverona1/ESP32_NTPNixieClock/issues/2)

- **Flicker Mode for Anti-Poisoning**:  
  A new flicker mode has been added for the anti-poisoning feature, similar to the original clock code.

  - The `flickerMode` variable controls the animation:
    - `true`: Chaotic random flickering effect across all nixie digits for anti-poisoning.
    - `false`: Cycles digits sequentially with LED color changes and dot blinking.

  ```cpp
  bool flickerMode = false; // Default to normal mode
